### PR TITLE
Fix eipw errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ title: Proof of Solvency for Centralized Exchanges
 description: A standard for centralized exchanges to cryptographically prove solvency without revealing user balances and aggregate information.
 author: Enrico Bottazzi (@enricobottazzi), Alex Kuzmin (@alxkzmn), Jin Hwan (@sifnoc)
 discussions-to: https://ethereum-magicians.org/t/eip-draft-proof-of-solvency-standard-for-centralized-exchanges/15963
-status: draft
+status: Draft
 type: Standards Track
 category: ERC
 created: 2023-08-30

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The implementation of this standard is expected to be fully backward compatible.
 
 ## Reference Implementation
 
-The [Summa](https://github.com/summa-dev) team (supported by the Privacy and Scaling Explorations team) has created a reference implementation [here](https://github.com/summa-dev/summa-solvency).
+The Summa team (supported by the Privacy and Scaling Explorations team) has created a reference implementation that can be found in the discussion link specified in the preamble of this document.
 
 ## Security Considerations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 title: Proof of Solvency for Centralized Exchanges
-description: A standard for centralized exchanges to cryptographically prove solvency without revealing user balances and aggregate information.
+description: Proof of solvency for centralized exchanges without revealing user balances and aggregate information.
 author: Enrico Bottazzi (@enricobottazzi), Alex Kuzmin (@alxkzmn), Jin Hwan (@sifnoc)
 discussions-to: https://ethereum-magicians.org/t/eip-draft-proof-of-solvency-standard-for-centralized-exchanges/15963
 status: Draft

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 title: Proof of Solvency for Centralized Exchanges
-description: A standard for centralized exchanges to cryptographically prove their solvency without revealing information about individual user balances and aggregated information related to user balances.
+description: A standard for centralized exchanges to cryptographically prove solvency without revealing user balances and aggregate information.
 author: Enrico Bottazzi (@enricobottazzi), Alex Kuzmin (@alxkzmn), Jin Hwan (@sifnoc)
 discussions-to: https://ethereum-magicians.org/t/eip-draft-proof-of-solvency-standard-for-centralized-exchanges/15963
 status: draft


### PR DESCRIPTION
Fixes a bunch of errors as validated by the [eipw](https://github.com/ethereum/eipw) binary.

**Things fixed:**
- non-relative links taken out
- description shortened and the word "standard" removed
- capitalize the word "Draft" in the preamble status

**Things not fixed:**
- broken link to the license (should pass for the actual repo)
- missing EIP number (will add it in for the actual PR)

# Appendix: Original Error Log

```
➜  eip-draft git:(main) eipw README.md
error[markdown-rel-links]: non-relative link or image
   --> README.md
    |
159 | The [Summa](https://github.com/summa-dev) team (supported by the Privacy and Scaling Explorations team) has created a reference implementation [here](https://github.com/summa-dev/summa-solvency).
    |
    = help: see https://ethereum.github.io/eipw/markdown-rel-links/
error[markdown-rel-links]: non-relative link or image
   --> README.md
    |
159 | The [Summa](https://github.com/summa-dev) team (supported by the Privacy and Scaling Explorations team) has created a reference implementation [here](https://github.com/summa-dev/summa-solvency).
    |
error[markdown-rel-links]: non-relative link or image
   --> README.md
    |
169 | Copyright and related rights waived via [CC0](/LICENSE).
    |
error[preamble-enum-status]: preamble header `status` has an unrecognized value
 --> README.md:6:8
  |
6 | status: draft
  |        ^^^^^^ must be one of: `Draft`, `Review`, `Last Call`, `Final`, `Stagnant`, `Withdrawn`, `Living`
  |
  = help: see https://ethereum.github.io/eipw/preamble-enum-status/
error[preamble-len-description]: preamble header `description` value is too long (max 140)
 --> README.md:3:13
  |
3 | description: A standard for centralized exchanges to cryptographically prove their solvency without revealing information about individual user balances and aggregated information related to user balances.
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ too long
  |
  = help: see https://ethereum.github.io/eipw/preamble-len-description/
error[preamble-re-description]: preamble header `description` should not contain `standard` (or similar words.)
 --> README.md:3:13
  |
3 | description: A standard for centralized exchanges to cryptographically prove their solvency without revealing information about individual user balances and aggregated information related to user balances.
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ prohibited pattern was matched
  |
  = info: the pattern in question: `(?i)standar\w*\b`
  = help: see https://ethereum.github.io/eipw/preamble-re-description/
error[preamble-req]: preamble is missing header(s): `eip`
--> README.md
 |
 |
 = help: see https://ethereum.github.io/eipw/preamble-req/
validation failed with 7 errors :(
```

